### PR TITLE
Switch from using the ssh url to the github url for lighthouse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,8 +4834,8 @@
       }
     },
     "lighthouse": {
-      "version": "git+ssh://git@github.com/GoogleChrome/lighthouse.git#a1571ba4bc5b7713248ea53e01db085389e634f8",
-      "from": "git+ssh://git@github.com/GoogleChrome/lighthouse.git#a1571ba4bc5b7713248ea53e01db085389e634f8",
+      "version": "github:GoogleChrome/lighthouse#a1571ba4bc5b7713248ea53e01db085389e634f8",
+      "from": "github:GoogleChrome/lighthouse#a1571ba4bc5b7713248ea53e01db085389e634f8",
       "requires": {
         "axe-core": "3.5.5",
         "chrome-launcher": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "csv": "^5.3.2",
-    "lighthouse": "git@github.com:GoogleChrome/lighthouse.git#a1571ba4bc5b7713248ea53e01db085389e634f8",
+    "lighthouse": "github:GoogleChrome/lighthouse#a1571ba4bc5b7713248ea53e01db085389e634f8",
     "sanitize-filename": "^1.6.3",
     "simplecrawler": "^1.1.9"
   },


### PR DESCRIPTION
Before, when I did `npm ci`, it was asking me for my ssh key to clone lighthouse, and then it wasn't working when I put it in. I changed it to clone lighthouse with https instead of ssh, and now it doesn't ask for my ssh key ✅ 