### PR TITLE
Switch it to use process.cwd() instead of __dirname, except for tests

### DIFF
--- a/scan_task.ts
+++ b/scan_task.ts
@@ -11,7 +11,7 @@ const {
   usefulDirName,
 } = require('./utilities');
 const siteUrl = process.argv[2];
-const dir = path.join(__dirname, 'data', usefulDirName());
+const dir = path.join(process.cwd(), 'data', usefulDirName());
 
 // Set up for lighthouse reports
 const reportFormat = 'csv'; // Html works too

--- a/urls_task.ts
+++ b/urls_task.ts
@@ -8,7 +8,7 @@ const siteUrl = process.argv[2];
 const respectRobots = false;
 const crawler = new Crawler(siteUrl);
 
-const dir = path.join(__dirname, 'data', `${Date.now()}`);
+const dir = path.join(process.cwd(), 'data', `${Date.now()}`);
 fs.mkdirSync(dir, { recursive: true });
 const file = `${dir}/urls.csv`;
 fs.writeFileSync(file, 'URL,content_type,bytes,response\n', {


### PR DESCRIPTION
This fixes #18. Now the `data` folder should be placed in the folder you run the command from, rather than relative to the location of the source files.

This is also a good change for if we eventually change this to be a regular CLI that we can use like this:

```
npm i -g lighthouse-parade
lighthouse-parade scan http://www.dfwfreeways.com/
```