### PR TITLE
Add CLI entrypoint that passes args to scan task

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ It is also easy to graph data in this format. The following example is a histogr
 ## Installation
 
 1. `nvm use` (if you use NVM)
-2. `npm install`
+2. `npm ci`
 3. `npm run build`
 4. `npm link`
 
 ## Usage
 
-`lighthouse-parade scan <URL>`
+`lighthouse-parade <URL>`
 
-Ex: `lighthouse-parade scan http://www.dfwfreeways.com/`
+Ex: `lighthouse-parade http://www.dfwfreeways.com/`
 
 Runs a crawler on the provided URL. Discovers all URLs and runs a lighthouse report on each HTML page, then writes them to a CSV file located in `./data/<timestamp>/urls.csv`. The individual reports are written to `./data/<timestamp>/reports/`. At the end, each report file is bundled into one aggregated report CSV with each row representing a URL and each column is a metric.
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ It is also easy to graph data in this format. The following example is a histogr
 1. `nvm use` (if you use NVM)
 2. `npm install`
 3. `npm run build`
+4. `npm link`
 
 ## Usage
 
-`npm run scan -- <URL>`
+`lighthouse-parade scan <URL>`
 
-Ex: `npm run scan -- http://www.dfwfreeways.com/`
+Ex: `lighthouse-parade scan http://www.dfwfreeways.com/`
 
 Runs a crawler on the provided URL. Discovers all URLs and runs a lighthouse report on each HTML page, then writes them to a CSV file located in `./data/<timestamp>/urls.csv`. The individual reports are written to `./data/<timestamp>/reports/`. At the end, each report file is bundled into one aggregated report CSV with each row representing a URL and each column is a metric.
 

--- a/cli.ts
+++ b/cli.ts
@@ -6,17 +6,11 @@ import { usefulDirName } from './utilities';
 import * as path from 'path';
 import { version } from './package.json';
 
-const program = sade('lighthouse-parade');
-
-program.version(version);
-
-program
-  .command(
-    'scan <url> [dataDirectory]',
-    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM',
-    { default: true }
+sade('lighthouse-parade <url> [dataDirectory]', true)
+  .version(version)
+  .describe(
+    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM'
   )
-  .alias('s')
   .option(
     '--ignore-robots',
     "Crawl pages even if they are listed in the site's robots.txt",
@@ -36,6 +30,5 @@ program
       const ignoreRobotsTxt: boolean = opts['ignore-robots'];
       scan(url, { ignoreRobotsTxt, dataDirectory });
     }
-  );
-
-program.parse(process.argv);
+  )
+  .parse(process.argv);

--- a/cli.ts
+++ b/cli.ts
@@ -9,7 +9,7 @@ import { version } from './package.json';
 sade('lighthouse-parade <url> [dataDirectory]', true)
   .version(version)
   .describe(
-    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM'
+    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults to ./data/YYYY-MM-DDTTZ_HH_MM'
   )
   .option(
     '--ignore-robots',

--- a/cli.ts
+++ b/cli.ts
@@ -17,7 +17,7 @@ program
   )
   .alias('s')
   .option(
-    '--ignore-robots-txt',
+    '--ignore-robots',
     "Crawl pages even if they are listed in the site's robots.txt",
     false
   )
@@ -32,7 +32,7 @@ program
       // the prorgam will exit here instead of continuing (which would lead to a more confusing error)
       // eslint-disable-next-line no-new
       new URL(url);
-      const ignoreRobotsTxt: boolean = opts['ignore-robots-txt'];
+      const ignoreRobotsTxt: boolean = opts['ignore-robots'];
       scan(url, { ignoreRobotsTxt, dataDirectory });
     }
   );

--- a/cli.ts
+++ b/cli.ts
@@ -4,10 +4,11 @@ import sade from 'sade';
 import { scan } from './scan-task';
 import { usefulDirName } from './utilities';
 import * as path from 'path';
+import { version } from './package.json';
 
 const program = sade('lighthouse-parade');
 
-program.version('0.0.0');
+program.version(version);
 
 program
   .command(

--- a/cli.ts
+++ b/cli.ts
@@ -13,7 +13,8 @@ program.version(version);
 program
   .command(
     'scan <url> [dataDirectory]',
-    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM'
+    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM',
+    { default: true }
   )
   .alias('s')
   .option(

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import sade from 'sade';
+import { scan } from './scan-task';
+import { usefulDirName } from './utilities';
+import * as path from 'path';
+
+const program = sade('lighthouse-parade');
+
+program.version('0.0.0');
+
+program
+  .command(
+    'scan <url> [dataDirectory]',
+    'Crawls the site at the provided URL, recording the lighthouse scores for each URL found. The lighthouse data will be stored in the provided directory, which defaults ./data/YYYY-MM-DDTTZ_HH_MM'
+  )
+  .alias('s')
+  .option(
+    '--ignore-robots-txt',
+    "Crawl pages even if they are listed in the site's robots.txt",
+    false
+  )
+  .action(
+    (
+      url,
+      // eslint-disable-next-line default-param-last
+      dataDirectory = path.join(process.cwd(), 'data', usefulDirName()),
+      opts
+    ) => {
+      // We are attempting to parse the URL here, so that if the user passes an invalid URL,
+      // the prorgam will exit here instead of continuing (which would lead to a more confusing error)
+      // eslint-disable-next-line no-new
+      new URL(url);
+      const ignoreRobotsTxt: boolean = opts['ignore-robots-txt'];
+      scan(url, { ignoreRobotsTxt, dataDirectory });
+    }
+  );
+
+program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-parade",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,6 +2116,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/mri": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mri/-/mri-1.1.0.tgz",
+      "integrity": "sha512-fMl88ZoZXOB7VKazJ6wUMpZc9QIn+jcigSFRf2K/rrw4DcXn+/uGxlWX8DDlcE7JkwgIZ7BDH+JgxZPlc/Ap3g==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
@@ -2132,6 +2138,15 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
       "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
       "dev": true
+    },
+    "@types/sade": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@types/sade/-/sade-1.7.2.tgz",
+      "integrity": "sha512-qVHZ70gLk2tCAqRanVOBVKM8og7eBhnWx1cdHMj8J3t4QF+PzIS9+pzZWZEx9ghsO1DDeGOTgyq5aQd5Bt/2dw==",
+      "dev": true,
+      "requires": {
+        "@types/mri": "*"
+      }
     },
     "@types/simplecrawler": {
       "version": "1.1.1",
@@ -7514,6 +7529,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -8503,6 +8523,14 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
         "rx-lite": "*"
+      }
+    },
+    "sade": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.3.tgz",
+      "integrity": "sha512-m4BctppMvJ60W1dXnHq7jMmFe3hPJZDAH85kQ3ACTo7XZNVUuTItCQ+2HfyaMeV5cKrbw7l4vD/6We3GBxvdJw==",
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-parade",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "A Node.js command line tool that crawls a domain and compiles a report with lighthouse performance data for every page.",
   "bin": "dist/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "lighthouse-parade",
   "version": "1.0.0",
   "description": "A Node.js command line tool that crawls a domain and compiles a report with lighthouse performance data for every page.",
+  "bin": "dist/cli.js",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
     "urls": "node dist/urls-task.js",
     "combine": "node dist/combine-task.js",
-    "scan": "node dist/scan-task.js",
     "check-lint": "eslint . && prettier --check .",
     "lint": "eslint --fix . && prettier --write .",
     "type": "tsc --noEmit",
@@ -22,8 +22,12 @@
     "csv-parse": "^4.12.0",
     "csv-stringify": "^5.5.1",
     "lighthouse": "github:GoogleChrome/lighthouse#a1571ba4bc5b7713248ea53e01db085389e634f8",
+    "sade": "^1.7.3",
     "sanitize-filename": "^1.6.3",
     "simplecrawler": "^1.1.9"
+  },
+  "engines": {
+    "node": ">12.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -31,6 +35,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@cloudfour/eslint-plugin": "^14.0.0",
     "@types/jest": "^26.0.14",
+    "@types/sade": "^1.7.2",
     "@types/simplecrawler": "^1.1.1",
     "eslint": "^7.9.0",
     "eslint-plugin-jest": "^24.0.2",

--- a/scan-task.ts
+++ b/scan-task.ts
@@ -3,86 +3,88 @@ import fs from 'fs';
 import path from 'path';
 import { runReport, makeFileNameFromUrl } from './lighthouse';
 import { aggregateCSVReports } from './combine';
-import {
-  fileDoesntExist,
-  isContentTypeHtml,
-  usefulDirName,
-  makeUrlRow,
-} from './utilities';
+import { fileDoesntExist, isContentTypeHtml, makeUrlRow } from './utilities';
 import type { QueueItem } from 'simplecrawler/queue';
 import type { IncomingMessage } from 'http';
-const siteUrl = process.argv[2];
-const dir = path.join(process.cwd(), 'data', usefulDirName());
 
-// Set up for lighthouse reports
-const reportFormat = 'csv'; // Html works too
-const reportDirName = 'reports';
-const reportsDirPath = `${dir}/${reportDirName}`;
-fs.mkdirSync(reportsDirPath, { recursive: true });
+interface ScanOptions {
+  /** Whether to crawl pages even if they are listed in the site's robots.txt */
+  ignoreRobotsTxt: boolean;
+  /** Where to store the newly-generated reports */
+  dataDirectory: string;
+}
+export const scan = (siteUrl: string, opts: ScanOptions) => {
+  const dir = opts.dataDirectory;
+  // Set up for lighthouse reports
+  const reportFormat = 'csv'; // Html works too
+  const reportDirName = 'reports';
+  const reportsDirPath = `${dir}/${reportDirName}`;
+  fs.mkdirSync(reportsDirPath, { recursive: true });
 
-// Set up for crawler
-const crawler = new Crawler(siteUrl);
-crawler.respectRobotsTxt = true;
-fs.mkdirSync(dir, { recursive: true });
-const file = `${dir}/urls.csv`;
-fs.writeFileSync(file, 'URL,content_type,bytes,response\n', {
-  encoding: 'utf-8',
-});
-/** Used so we can display an error if no pages are found while crawling */
-let hasFoundAnyPages = false;
-console.log('Created CSV file');
-const stream = fs.createWriteStream(file, { flags: 'a' });
-crawler.on('fetchcomplete', (queueItem, responseBuffer, response) => {
-  hasFoundAnyPages = true;
-  console.log(
-    'Crawled %s [%s] (%d bytes)',
-    queueItem.url,
-    response.headers['content-type'],
-    responseBuffer.length
-  );
-  stream.write(makeUrlRow(queueItem, responseBuffer, response));
-  const reportFileName = makeFileNameFromUrl(queueItem.url, reportFormat);
-  if (!fileDoesntExist(reportFileName, reportsDirPath)) {
-    console.log('Skipping report because file already exists');
-    return;
-  }
+  // Set up for crawler
+  const crawler = new Crawler(siteUrl);
+  crawler.respectRobotsTxt = !opts.ignoreRobotsTxt;
+  fs.mkdirSync(dir, { recursive: true });
+  const file = `${dir}/urls.csv`;
+  fs.writeFileSync(file, 'URL,content_type,bytes,response\n', {
+    encoding: 'utf-8',
+  });
+  /** Used so we can display an error if no pages are found while crawling */
+  let hasFoundAnyPages = false;
+  console.log('Created CSV file');
+  const stream = fs.createWriteStream(file, { flags: 'a' });
+  crawler.on('fetchcomplete', (queueItem, responseBuffer, response) => {
+    hasFoundAnyPages = true;
+    console.log(
+      'Crawled %s [%s] (%d bytes)',
+      queueItem.url,
+      response.headers['content-type'],
+      responseBuffer.length
+    );
+    stream.write(makeUrlRow(queueItem, responseBuffer, response));
+    const reportFileName = makeFileNameFromUrl(queueItem.url, reportFormat);
+    if (!fileDoesntExist(reportFileName, reportsDirPath)) {
+      console.log('Skipping report because file already exists');
+      return;
+    }
 
-  if (!isContentTypeHtml(response.headers['content-type'])) {
-    return;
-  }
+    if (!isContentTypeHtml(response.headers['content-type'])) {
+      return;
+    }
 
-  const reportData = runReport(queueItem.url, reportFormat);
-  if (!reportData) return;
-  fs.writeFileSync(`${reportsDirPath}/${reportFileName}`, reportData);
-  console.log(`Wrote report for ${queueItem.url}`);
-});
-crawler.on('complete', function () {
-  console.log('Scan complete');
-  if (!hasFoundAnyPages) {
-    console.error(`No pages were found for this site. The two most likely reasons for this are:
+    const reportData = runReport(queueItem.url, reportFormat);
+    if (!reportData) return;
+    fs.writeFileSync(`${reportsDirPath}/${reportFileName}`, reportData);
+    console.log(`Wrote report for ${queueItem.url}`);
+  });
+  crawler.on('complete', function () {
+    console.log('Scan complete');
+    if (!hasFoundAnyPages) {
+      console.error(`No pages were found for this site. The two most likely reasons for this are:
 1) the URL is incorrect
 2) the crawler is being denied by a robots.txt file`);
-    return;
+      return;
+    }
+
+    console.log('Aggregating reports...');
+    const aggregatedReportData = aggregateCSVReports(reportsDirPath);
+    if (!aggregatedReportData) return;
+
+    const writePath = path.join(dir, 'aggregatedMobileReport.csv');
+    fs.writeFile(writePath, aggregatedReportData, (e) => {
+      if (e) {
+        console.error(e);
+      }
+    });
+    console.log('DONE!');
+  });
+  crawler.on('fetcherror', logError);
+  crawler.on('fetch404', logError);
+  crawler.on('fetch410', logError);
+  function logError(queueItem: QueueItem, response: IncomingMessage) {
+    console.log(`Error fetching (${response.statusCode}): ${queueItem.url}`);
   }
 
-  console.log('Aggregating reports...');
-  const aggregatedReportData = aggregateCSVReports(reportsDirPath);
-  if (!aggregatedReportData) return;
-
-  const writePath = path.join(dir, 'aggregatedMobileReport.csv');
-  fs.writeFile(writePath, aggregatedReportData, (e) => {
-    if (e) {
-      console.error(e);
-    }
-  });
-  console.log('DONE!');
-});
-crawler.on('fetcherror', logError);
-crawler.on('fetch404', logError);
-crawler.on('fetch410', logError);
-function logError(queueItem: QueueItem, response: IncomingMessage) {
-  console.log(`Error fetching (${response.statusCode}): ${queueItem.url}`);
-}
-
-console.log('Starting the crawl...');
-crawler.start();
+  console.log('Starting the crawl...');
+  crawler.start();
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["lighthouse/types/lhr", "jest"],
     "importsNotUsedAsValues": "error"


### PR DESCRIPTION
This PR handles the first two steps of #25. I will create a follow-up PR that sets up publishing, then we can close #25

Closes #26 

Testing:

- `npm run build`
- `npm link`
- `lighthouse-parade --help`
- `lighthouse-parade https://lombardstreettattoo.com/`
- `lighthouse-parade https://lombardstreettattoo.com/ some-folder`
- `lighthouse-parade https://lombardstreettattoo.com/ --ignore-robots`