### PR TITLE
Fix publish

### DIFF
--- a/.changeset/wise-snails-mate.md
+++ b/.changeset/wise-snails-mate.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': patch
+---
+
+Fix published files

--- a/cli.ts
+++ b/cli.ts
@@ -4,7 +4,16 @@ import sade from 'sade';
 import { scan } from './scan-task';
 import { usefulDirName } from './utilities';
 import * as path from 'path';
-import { version } from './package.json';
+/*
+This is a require because if it was an import, TS would copy package.json to `dist`
+If TS copied package.json to `dist`, npm would not publish the JS files in `dist`
+Since it is a require, TS leaves it as-is, which means that the require path
+has to be relative to the built version of this file in the dist folder
+It may in the future make sense to use a bundler to combine all the dist/ files into one file,
+(including package.json) which would eliminate this problem
+*/
+// eslint-disable-next-line @cloudfour/typescript-eslint/no-var-requires
+const { version } = require('../package.json');
 
 sade('lighthouse-parade <url> [dataDirectory]', true)
   .version(version)


### PR DESCRIPTION
There is a description of the issue in the code comment.

## Testing

**Reproduce bug on `master`**:
- `git checkout master`
- `rm -rf dist`
- `npm run build`
- `npm pack`. The output will include a list of files that it put in the .tgz. Verify that it is _missing_ the JS files from `dist`
- Delete the `.tgz` it created

**Confirm fix**
- `git checkout fix-publish`
- `rm -rf dist`
- `npm run build`
- `npm pack`. The output will include a list of files that it put in the .tgz. Verify that it _includes_ all the JS files from `dist`
- Delete the `.tgz` it created

I marked it as a patch release since it is just a bug fix. Feel free to change the version bump in the `.changeset` file if you want.