### PR TITLE
Make lighthouse reports concurrent

### DIFF
--- a/.changeset/polite-foxes-compete.md
+++ b/.changeset/polite-foxes-compete.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': minor
+---
+
+Run lighthouse instances concurrently, and change CLI output

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-data
+lighthouse-parade-data
 node_modules
 /dist

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Runs a crawler on the provided URL. Discovers all URLs and runs a lighthouse rep
 ### Options
 
 ```
---ignore-robots         Crawl pages even if they are listed in the site's robots.txt  (default false)
---crawler-user-agent    Pass a user agent string to be used by the crawler (not by Lighthouse)
--v, --version           Displays current version
--h, --help              Displays help text
+--ignore-robots             Crawl pages even if they are listed in the site's robots.txt  (default false)
+--crawler-user-agent        Pass a user agent string to be used by the crawler (not by Lighthouse)
+--lighthouse-concurrency    Control the maximum number of ligthhouse reports to run concurrency  (default  number of CPU cores minus one)
+-v, --version               Displays current version
+-h, --help                  Displays help text
 ```
 
 ## Versioning Notice

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Runs a crawler on the provided URL. Discovers all URLs and runs a lighthouse rep
 ### Options
 
 ```
---ignore-robots             Crawl pages even if they are listed in the site's robots.txt  (default false)
+--ignore-robots             Crawl pages even if they are listed in the site's robots.txt  (default: false)
 --crawler-user-agent        Pass a user agent string to be used by the crawler (not by Lighthouse)
---lighthouse-concurrency    Control the maximum number of ligthhouse reports to run concurrency  (default  number of CPU cores minus one)
+--lighthouse-concurrency    Control the maximum number of ligthhouse reports to run concurrently  (default: number of CPU cores minus one)
 -v, --version               Displays current version
 -h, --help                  Displays help text
 ```

--- a/cli.ts
+++ b/cli.ts
@@ -40,7 +40,7 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
   )
   .option(
     '--lighthouse-concurrency',
-    'Control the maximum number of ligthhouse reports to run concurrency',
+    'Control the maximum number of ligthhouse reports to run concurrently',
     os.cpus().length - 1
   )
   .action(

--- a/cli.ts
+++ b/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import * as fs from 'fs';
+import * as os from 'os';
+import * as kleur from 'kleur/colors';
+import logUpdate from 'log-update';
 import * as path from 'path';
 import sade from 'sade';
 import { scan } from './scan-task';
@@ -16,6 +19,11 @@ It may in the future make sense to use a bundler to combine all the dist/ files 
 // eslint-disable-next-line @cloudfour/typescript-eslint/no-var-requires
 const { version } = require('../package.json');
 
+const symbols = {
+  error: kleur.red('✖'),
+  success: kleur.green('✔'),
+};
+
 sade('lighthouse-parade <url> [dataDirectory]', true)
   .version(version)
   .describe(
@@ -29,6 +37,11 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
   .option(
     '--crawler-user-agent',
     'Pass a user agent string to be used by the crawler (not by Lighthouse)'
+  )
+  .option(
+    '--lighthouse-concurrency',
+    'Control the maximum number of ligthhouse reports to run concurrency',
+    os.cpus().length - 1
   )
   .action(
     (
@@ -54,14 +67,98 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
         throw new Error('--crawler-user-agent flag must be a string');
       }
 
-      const scanner = scan(url, { ignoreRobotsTxt, dataDirectory });
+      const lighthouseConcurrency = opts['lighthouse-concurrency'];
+
+      const scanner = scan(url, {
+        ignoreRobotsTxt,
+        dataDirectory,
+        lighthouseConcurrency,
+      });
+
+      const enum State {
+        Pending,
+        ReportInProgress,
+        ReportComplete,
+      }
+      const urlStates = new Map<
+        string,
+        { state: State; error?: Error | string }
+      >();
+
+      const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+      let i = 0;
+
+      const printLine = (url: string, state: State, error?: Error | string) => {
+        const frame = kleur.blue(frames[i]);
+        const statusIcon = error
+          ? symbols.error
+          : state === State.Pending
+          ? ' '
+          : state === State.ReportInProgress
+          ? frame
+          : symbols.success;
+        let output = `${statusIcon} ${url}`;
+        if (error) {
+          output += `\n  ${kleur.gray(error.toString())}`;
+        }
+
+        return output;
+      };
+
+      const render = () => {
+        const pendingUrls: string[] = [];
+        const currentUrls: string[] = [];
+        urlStates.forEach(({ state, error }, url) => {
+          if (state === State.ReportComplete) return;
+          const line = `${printLine(url, state, error)}\n`;
+          if (state === State.Pending) pendingUrls.push(line);
+          else currentUrls.push(line);
+        });
+        const numPendingToDisplay = Math.min(
+          Math.max(process.stdout.rows - currentUrls.length - 3, 1),
+          pendingUrls.length
+        );
+        const numHiddenUrls =
+          numPendingToDisplay === pendingUrls.length
+            ? ''
+            : kleur.dim(
+                `\n...And ${
+                  pendingUrls.length - numPendingToDisplay
+                } more pending`
+              );
+        logUpdate(
+          currentUrls.join('') +
+            pendingUrls.slice(0, numPendingToDisplay).join('') +
+            numHiddenUrls
+        );
+      };
+
+      const intervalId = setInterval(() => {
+        i = (i + 1) % frames.length;
+        render();
+      }, 80);
+
+      /**
+       * Allows you to run a console.log that will output _above_ the persistent logUpdate log
+       * Pass a callback where you run your console.log or console.error
+       */
+      const printAboveLogUpdate = (cb: () => void) => {
+        logUpdate.clear();
+        cb();
+        render();
+      };
+
+      const log = (...messages: string[]) =>
+        printAboveLogUpdate(() => console.log(...messages));
+      const error = (...messages: string[]) =>
+        printAboveLogUpdate(() => console.error(...messages));
 
       const urlsFile = path.join(dataDirectory, 'urls.csv');
       fs.writeFileSync(urlsFile, 'URL,content_type,bytes,response\n');
       const urlsStream = fs.createWriteStream(urlsFile, { flags: 'a' });
 
       scanner.on('urlFound', (url, contentType, bytes, statusCode) => {
-        console.log('Crawled %s [%s] (%d bytes)', url, contentType, bytes);
+        urlStates.set(url, { state: State.Pending });
         const csvLine = [
           JSON.stringify(url),
           contentType,
@@ -70,15 +167,28 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
         ].join(',');
         urlsStream.write(`${csvLine}\n`);
       });
+      scanner.on('reportBegin', (url) => {
+        urlStates.set(url, { state: State.ReportInProgress });
+      });
+      scanner.on('reportFail', (url, error) => {
+        urlStates.set(url, { state: State.ReportComplete, error });
+        log(printLine(url, State.ReportComplete, error));
+      });
       scanner.on('reportComplete', (url, reportData) => {
-        console.log('Report is done for', url);
+        urlStates.set(url, { state: State.ReportComplete });
+        log(printLine(url, State.ReportComplete));
         const reportFileName = makeFileNameFromUrl(url, 'csv');
 
         fs.writeFileSync(path.join(reportsDirPath, reportFileName), reportData);
       });
 
       scanner.on('info', (message) => {
-        console.log(message);
+        log(message);
+      });
+
+      scanner.promise.then(() => {
+        clearInterval(intervalId);
+        console.log('DONE!');
       });
     }
   )

--- a/cli.ts
+++ b/cli.ts
@@ -150,8 +150,6 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
 
       const log = (...messages: string[]) =>
         printAboveLogUpdate(() => console.log(...messages));
-      const error = (...messages: string[]) =>
-        printAboveLogUpdate(() => console.error(...messages));
 
       const urlsFile = path.join(dataDirectory, 'urls.csv');
       fs.writeFileSync(urlsFile, 'URL,content_type,bytes,response\n');

--- a/crawl.ts
+++ b/crawl.ts
@@ -34,6 +34,8 @@ export const crawl = (siteUrl: string, opts: CrawlOptions) => {
     );
   };
 
+  emit('urlFound', 'https://google.com/asdff', 'text/html', 100, 200);
+
   crawler.on('fetchcomplete', (queueItem, responseBuffer, response) => {
     const url = queueItem.url;
     const contentType = response.headers['content-type'];

--- a/crawl.ts
+++ b/crawl.ts
@@ -34,8 +34,6 @@ export const crawl = (siteUrl: string, opts: CrawlOptions) => {
     );
   };
 
-  emit('urlFound', 'https://google.com/asdff', 'text/html', 100, 200);
-
   crawler.on('fetchcomplete', (queueItem, responseBuffer, response) => {
     const url = queueItem.url;
     const contentType = response.headers['content-type'];

--- a/emitter.ts
+++ b/emitter.ts
@@ -20,6 +20,7 @@ export const createEmitter = <Events extends EventMap, Resolve = never>() => {
 
   const on = <E extends keyof Events>(eventName: E, handler: Events[E]) => {
     (eventHandlers[eventName] ??= [] as Events[E][]).push(handler);
+    return emitter; // Allow chaining
   };
 
   const promise = new Promise<Resolve>((resolve, reject) => {
@@ -28,13 +29,14 @@ export const createEmitter = <Events extends EventMap, Resolve = never>() => {
   });
   const eventHandlers: { [E in keyof Events]?: Events[E][] } = {};
   interface Emit {
-    (eventName: 'resolve', value?: Resolve): void;
-    (eventName: 'reject', value?: unknown): void;
     <E extends keyof Events>(
       eventName: E,
       ...args: Parameters<Events[E]>
     ): void;
+    (eventName: 'resolve', value?: Resolve): void;
+    (eventName: 'reject', value?: unknown): void;
   }
 
-  return { promise, on, emit };
+  const emitter = { promise, on, emit };
+  return emitter;
 };

--- a/lighthouse.ts
+++ b/lighthouse.ts
@@ -1,25 +1,76 @@
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
+import { createEmitter } from './emitter';
 
 const lighthouseCli = require.resolve('lighthouse/lighthouse-cli');
+
+let lighthouseLimit = 2;
+let currentLighthouseInstances = 0;
+const lighthouseQueue: (() => void)[] = [];
+
+const runLighthouseQueue = () => {
+  while (
+    lighthouseQueue.length > 0 &&
+    currentLighthouseInstances < lighthouseLimit
+  ) {
+    const run = lighthouseQueue.shift() as () => void;
+    currentLighthouseInstances++;
+    run();
+  }
+};
+
+type LighthouseEvents = {
+  begin: () => void;
+  complete: (reportData: string) => void;
+  error: (message: Error) => void;
+};
 
 // This function is marked as async to wrap it with a promise to make error handling easier
 // Even though the underlying process is spawned synchronously
 // eslint-disable-next-line @cloudfour/typescript-eslint/require-await
-export const runLighthouseReport = async (url: string) => {
-  const { status = -1, stdout } = spawnSync('node', [
-    lighthouseCli,
-    url,
-    '--output=csv',
-    '--output-path=stdout',
-    '--emulated-form-factor=mobile',
-    '--only-categories=performance',
-    '--chrome-flags="--headless"',
-    '--max-wait-for-load=45000',
-  ]);
+export const runLighthouseReport = (url: string, maxConcurrency?: number) => {
+  if (maxConcurrency) lighthouseLimit = maxConcurrency;
+  const { on, emit } = createEmitter<LighthouseEvents>();
+  const run = () => {
+    emit('begin');
+    const lighthouseProcess = spawn('node', [
+      lighthouseCli,
+      url,
+      '--output=csv',
+      '--output-path=stdout',
+      '--emulated-form-factor=mobile',
+      '--only-categories=performance',
+      '--chrome-flags="--headless"',
+      '--max-wait-for-load=45000',
+    ]);
 
-  if (status !== 0) {
-    throw new Error(`Lighthouse report failed for: ${url}`);
-  }
+    let stdout = '';
+    let stderr = '';
 
-  return String(stdout).replace(/\r\n/g, '\n');
+    lighthouseProcess.stdout.on('data', (d) => {
+      stdout += d;
+    });
+
+    lighthouseProcess.stderr.on('data', (d) => {
+      if (/runtime error encountered/i.test(d)) stderr += d;
+    });
+
+    lighthouseProcess.on('close', (status) => {
+      if (status === 0) {
+        emit('complete', String(stdout).replace(/\r\n/g, '\n'));
+      } else {
+        emit(
+          'error',
+          new Error(stderr.trim() || `Lighthouse report failed for: ${url}`)
+        );
+      }
+
+      currentLighthouseInstances--;
+      runLighthouseQueue();
+    });
+  };
+
+  lighthouseQueue.push(run);
+  runLighthouseQueue();
+
+  return { on };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-parade",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7867,10 +7867,9 @@
       "dev": true
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.3.tgz",
+      "integrity": "sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw=="
     },
     "latest-version": {
       "version": "5.1.0",
@@ -8075,6 +8074,93 @@
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "lookup-closest-locale": {
       "version": "6.0.4",
@@ -9085,6 +9171,14 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+          "dev": true
+        }
       }
     },
     "ps-list": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "csv": "^5.3.2",
     "csv-parse": "^4.12.0",
     "csv-stringify": "^5.5.1",
+    "kleur": "^4.1.3",
     "lighthouse": "^6.4.0",
+    "log-update": "^4.0.0",
     "sade": "^1.7.3",
     "sanitize-filename": "^1.6.3",
     "simplecrawler": "^1.1.9"

--- a/test/scan-task.test.ts
+++ b/test/scan-task.test.ts
@@ -8,6 +8,7 @@ test('Displays useful error if no pages are found while crawling', async () => {
   const emitter = scan('https://nonexistent-website.com', {
     ignoreRobotsTxt: false,
     dataDirectory: 'foo',
+    lighthouseConcurrency: 1,
     crawler: fakeCrawler,
   });
 


### PR DESCRIPTION
The number of lighthouse instances defaults to the number of CPU cores minus 1. You can override this with the `--lighthouse-concurrency` flag.

When lighthouse errors it gets displayed like this:

![image](https://user-images.githubusercontent.com/13206945/97933836-b6573d00-1d28-11eb-9b7f-3f68f1809f4b.png)

When there are too many pending pages to display them all, they are cut off at the bottom. The terminal height is retrieved dynamically and it correctly handles resizes:

![image](https://user-images.githubusercontent.com/13206945/97933960-1f3eb500-1d29-11eb-99ee-c82d6c0ca5e5.png)

General comments about this PR:
I am very pleased with how the CLI output turned out. I am a little less pleased with the code that makes that CLI output appear. Would it be worth separating some of the CLI output logic into a separate module? Open to suggestions/refactorings.

For review:
- Test it with a bunch of URLs, make sure it works as expected
- Test the `--lighthouse-concurrency` flag
- I didn't add any tests for this. This seems like it is really hard to test. I'm open to suggestions for how to test it.

It is probably worth comparing the generated reports if `lighthouse-concurrency` is set to a high number vs if it is set to 1, to see if any of the performance metrics in the reports change.

Known problems that I don't plan to solve:
- If the URLs are long enough to wrap, there is some weirdness with the output, especially if you scroll up. It is still usable though. I could solve this, or we could just say that it is not a big enough problem to solve.
- If you resize the terminal to make it vertically smaller while it is running, there is also some weirdness with the output if you scroll up. It is still usable.