### PR TITLE
More readme changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Cloud Four
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Lighthouse Parade Hero Image](https://raw.githubusercontent.com/cloudfour/lighthouse-parade/master/assets/hero.svg)
 
-# Lighthouse Parade ![CI](https://github.com/cloudfour/lighthouse-parade/workflows/CI/badge.svg)
+# Lighthouse Parade [![CI](https://github.com/cloudfour/lighthouse-parade/workflows/CI/badge.svg)](https://github.com/cloudfour/lighthouse-parade/actions?query=workflow%3ACI) [![npm](https://img.shields.io/npm/v/lighthouse-parade)](https://www.npmjs.com/package/lighthouse-parade)
 
 A Node.js command line tool that crawls a domain and compiles a report with lighthouse performance data for every page.
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,15 @@ It is also easy to graph data in this format. The following example is a histogr
 
 ![Histogram showing LCP scores](./assets/lcp_histogram.svg)
 
-## Installation
+## Usage
 
 (Supports Node 12 and 14)
 
-`npm i -g lighthouse-parade`
-
-## Usage
-
 ```
-$ lighthouse-parade <url> [dataDirectory] [options]
+$ npx lighthouse-parade <url> [dataDirectory] [options]
 ```
 
-Ex: `lighthouse-parade http://www.dfwfreeways.com/`
+Ex: `npx lighthouse-parade http://www.dfwfreeways.com/`
 
 Runs a crawler on the provided URL. Discovers all URLs and runs a lighthouse report on each HTML page, then writes them to a CSV file located in `./lighthouse-parade-data/<timestamp>/urls.csv`. The individual reports are written to `./lighthouse-parade-data/<timestamp>/reports/`. At the end, each report file is bundled into one aggregated report CSV with each row representing a URL and each column is a metric.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Lighthouse Parade Hero Image](./assets/hero.svg)
+![Lighthouse Parade Hero Image](https://raw.githubusercontent.com/cloudfour/lighthouse-parade/master/assets/hero.svg)
 
 # Lighthouse Parade ![CI](https://github.com/cloudfour/lighthouse-parade/workflows/CI/badge.svg)
 


### PR DESCRIPTION
npx is a cli that comes bundled with node/npm and it will install the requested package to a tmp directory, which sidesteps issues with global installations of npm packages.

I also changed the hero image to point directly to github rather than using a relative path, because the hero image is not included in the npm package, so currently npm cannot render the image:
https://www.npmjs.com/package/lighthouse-parade

I also added a badge that links to the npm package

I also added a LICENSE file