### PR TITLE
[bugfix] force the initial path to be included in the crawling

### DIFF
--- a/.changeset/spotty-snakes-fry.md
+++ b/.changeset/spotty-snakes-fry.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': patch
+---
+
+Force the initial path to be included in the crawling regardless of include/exclude flags

--- a/crawl.ts
+++ b/crawl.ts
@@ -35,8 +35,13 @@ export const crawl = (siteUrl: string, opts: CrawlOptions) => {
   crawler.respectRobotsTxt = !opts.ignoreRobotsTxt;
   if (opts.maxCrawlDepth !== undefined) crawler.maxDepth = opts.maxCrawlDepth;
 
+  const initialPath = new URL(siteUrl).pathname;
+
   crawler.addFetchCondition(
-    createUrlFilter(opts.includePathGlob, opts.excludePathGlob)
+    createUrlFilter(
+      [...opts.includePathGlob, initialPath],
+      opts.excludePathGlob
+    )
   );
 
   const emitWarning = (queueItem: QueueItem, response: IncomingMessage) => {


### PR DESCRIPTION
Closes #94

When I wrote the `--help` text I was mistaken about the actual behavior, I wrote it based on the behavior I wanted 🙈. Optimistic documentation!!

Now I implemented the behavior as I intended for it to work.

Testing:

```
git checkout bugfix-force-include-root-path
npm i
npm run build
npm link
lighthouse-parade https://something.com/blog --include-path-glob "/blog/**"
```