### PR TITLE
Fix crawling when --include-path-glob is not passed

### DIFF
--- a/.changeset/quiet-bears-walk.md
+++ b/.changeset/quiet-bears-walk.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': patch
+---
+
+Fix crawling when --include-path-glob is not passed

--- a/cli.ts
+++ b/cli.ts
@@ -212,7 +212,9 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
         render();
       };
 
-      const log = (...messages: string[]) =>
+      const log = (...messages: any[]) =>
+        printAboveLogUpdate(() => console.log(...messages));
+      const warn = (...messages: any[]) =>
         printAboveLogUpdate(() => console.log(...messages));
 
       const urlsFile = path.join(dataDirPath, 'urls.csv');
@@ -246,6 +248,10 @@ sade('lighthouse-parade <url> [dataDirectory]', true)
 
       scanner.on('info', (message) => {
         log(message);
+      });
+
+      scanner.on('warning', (message) => {
+        warn(message);
       });
 
       scanner.promise.then(async () => {

--- a/crawl.ts
+++ b/crawl.ts
@@ -39,7 +39,9 @@ export const crawl = (siteUrl: string, opts: CrawlOptions) => {
 
   crawler.addFetchCondition(
     createUrlFilter(
-      [...opts.includePathGlob, initialPath],
+      opts.includePathGlob.length > 0
+        ? [...opts.includePathGlob, initialPath]
+        : [],
       opts.excludePathGlob
     )
   );


### PR DESCRIPTION
https://github.com/cloudfour/lighthouse-parade/pull/99 made it so that when `--include-path-glob` is passed, the initial URL is automatically included as well.
But, that PR broke the behavior when `--include-path-glob` was not passed. It made it so that the initial URL was implicitly the include-path-glob option, meaning that other URLs were not included.

This PR fixes that.

Testing:
- Test crawling with `--include-path-glob`
- Test crawling without `--include-path-glob`

Closes #102