### PR TITLE
Allow passing title to google sheets output writer

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ sade('lighthouse-parade <url>', true)
   )
   .option(
     '--output, -o',
-    'The output file(s). Can be specified multiple times, e.g. -o cloudfour-a.csv -o google-sheets'
+    'The output file(s). Can be specified multiple times, e.g. -o cloudfour-a.csv -o google-sheets -o google-sheets:"Spreadsheet Name"'
   )
   .option(
     '--ignore-robots-txt',

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,10 +26,17 @@ const getOutputWriter = async (
       if (output === 'google-sheets') {
         return createGoogleSheetsOutputWriter(initialUrl);
       }
+      const googleSheetsPrefix = 'google-sheets:';
+      if (output.startsWith(googleSheetsPrefix)) {
+        return createGoogleSheetsOutputWriter(
+          initialUrl,
+          output.slice(googleSheetsPrefix.length)
+        );
+      }
       const ext = path.extname(output);
       if (ext === '.csv') return createCSVOutputWriter(output);
       throw new Error(
-        `Invalid output format: ${ext} (${output}). Expected <filename>.csv, or google-sheets`
+        `Invalid output format: ${ext} (${output}). Expected <filename>.csv, or google-sheets, or google-sheets:"<title>"`
       );
     })
   );

--- a/src/output-writer/google-sheets-writer/index.ts
+++ b/src/output-writer/google-sheets-writer/index.ts
@@ -16,12 +16,15 @@ export const sheetNames = {
   runInfo: 'Run Info',
 };
 
-export const createGoogleSheetsOutputWriter = async (
-  initialUrl: string
-): Promise<OutputWriter> => {
+const getDefaultTitle = (initialUrl: string) => {
   const date = tinydate('{YYYY}-{MM}-{DD} {HH}:{mm}')(new Date());
-  const documentTitle = `Lighthouse ${new URL(initialUrl).hostname} ${date}`;
+  return `Lighthouse ${new URL(initialUrl).hostname} ${date}`;
+};
 
+export const createGoogleSheetsOutputWriter = async (
+  initialUrl: string,
+  documentTitle = getDefaultTitle(initialUrl)
+): Promise<OutputWriter> => {
   // Used to make sure that the addEntry calls happen one at a time
   // so they always write to the file in a deterministic order
   // (specifically important to make sure the header is first)
@@ -32,13 +35,12 @@ export const createGoogleSheetsOutputWriter = async (
 
   const spreadsheet: any = await service.spreadsheets
     .create({
-      // @ts-expect-error types are wrong
       resource: {
         properties: {
           title: documentTitle,
         },
       },
-    })
+    } as any)
     .then((r) => r);
 
   const spreadsheetId: string = spreadsheet.data.spreadsheetId;


### PR DESCRIPTION
Testing:

```
git checkout title-google-sheets
npm i
npm run build
npm link
lighthouse-parade https://cloudfour.com/ -o google-sheets:"Some Title" --max-crawl-depth 1
```
Check that the google sheet has the specified name, even if it has a space in it

Check that the default name is still passed if `-o google-sheets` is used