### PR TITLE
Output referrer when there is a crawl error - resolves #126

### DIFF
--- a/.changeset/happy-horses-invent.md
+++ b/.changeset/happy-horses-invent.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': patch
+---
+
+Output referrer when there is a crawl error

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -61,9 +61,7 @@ export function crawl(
     console.warn(
       `${kleur.yellow('⚠')} Error fetching (${response.statusCode}): ${
         queueItem.url
-      } - referrer: ${
-        queueItem.referrer
-      }`
+      } - referrer: ${queueItem.referrer}`
     );
   };
   crawler.on('fetcherror', logWarning);

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -61,6 +61,8 @@ export function crawl(
     console.warn(
       `${kleur.yellow('⚠')} Error fetching (${response.statusCode}): ${
         queueItem.url
+      } - referrer: ${
+        queueItem.referrer
       }`
     );
   };


### PR DESCRIPTION
Reapplied the changes to the next branch.

I am seeing a lint error in the build in the forked repo unrelated to these changes. Not totally sure why that's the case. 2 warnings related to: "warning  Async arrow function has too many parameters (5)"