### PR TITLE
Use lighthouse node API and restructure output writing (#111)

### DIFF
--- a/src/lighthouse-worker.ts
+++ b/src/lighthouse-worker.ts
@@ -1,25 +1,29 @@
 import { parentPort } from 'node:worker_threads';
 
-import chromeLauncher from 'chrome-launcher';
+import chromeLauncher, { LaunchedChrome } from 'chrome-launcher';
 import type { LHOptions } from 'lighthouse';
 import lighthouse from 'lighthouse';
 
 import type { LighthouseRunOpts } from './lighthouse.js';
 
-const chromePromise = chromeLauncher.launch({
-  chromeFlags: ['--headless', '--no-first-run'],
-});
+const chromeInstances = new Set<LaunchedChrome>();
+
 const runLighthouse = async (
   url: string,
   lighthouseRunOpts: LighthouseRunOpts
 ) => {
-  const chrome = await chromePromise;
+  const chrome = await chromeLauncher.launch({
+    chromeFlags: ['--headless', '--no-first-run'],
+  });
+  chromeInstances.add(chrome);
   const options: LHOptions = {
     output: 'json',
     onlyCategories: lighthouseRunOpts.categories,
     port: chrome.port,
   };
   const runnerResult = await lighthouse(url, options);
+  chrome.kill();
+  chromeInstances.delete(chrome);
   parentPort?.postMessage(runnerResult.lhr);
 };
 
@@ -27,11 +31,9 @@ parentPort?.on('message', (message) => {
   if (message.type === 'runLighthouse') {
     runLighthouse(message.url, message.lighthouseRunOpts);
   } else if (message.type === 'close') {
-    chromePromise
-      .then((chrome) => chrome.kill())
-      .then(() =>
-        // eslint-disable-next-line @cloudfour/n/no-process-exit, @cloudfour/unicorn/no-process-exit
-        process.exit(0)
-      );
+    Promise.all([...chromeInstances].map((chrome) => chrome.kill())).then(() =>
+      // eslint-disable-next-line @cloudfour/n/no-process-exit, @cloudfour/unicorn/no-process-exit
+      process.exit(0)
+    );
   }
 });


### PR DESCRIPTION
Previously, it was set to reuse them to save time. Sometime between Christmas and now, the chrome people changed something in chrome (or chrome devtools protocol) that makes it so that lighthouse can no longer reuse chrome instances. When I got back it just stopped working (I
didn't change the lighthouse version but chrome probably auto-updated).

[I opened an issue on lighthouse](GoogleChrome/lighthouse#14736), but there does not seem to be an easy resolution (other than that their @next version works). I am reluctant to make lighthouse-parade dependent on the lighthouse prerelease version.

So, for now, each chrome instance is used once and then thrown away.