### PR TITLE
Group interlocking dependencies in Renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,6 +5,30 @@
     {
       "matchDepTypes": ["peerDependencies", "engines"],
       "rangeStrategy": "replace"
+    },
+    {
+      "description": "ESLint and the shared config pin each other's plugins, so bumping either one alone produces a PR that crashes inside a lint rule. Keep them in a single PR.",
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint",
+        "@cloudfour/eslint-config",
+        "typescript-eslint"
+      ]
+    },
+    {
+      "description": "csv-parse and csv-stringify move their export paths together, and both are imported from the same modules here.",
+      "groupName": "csv",
+      "matchPackageNames": ["csv", "csv-parse", "csv-stringify"]
+    },
+    {
+      "description": "@types/node should track the oldest supported Node version from engines, not the newest, so that APIs unavailable on the floor fail to type-check. Raise this when the engines floor rises above Node 22.",
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "<23"
+    },
+    {
+      "description": "typescript-eslint declares typescript '>=4.8.4 <6.1.0', so TypeScript 7 breaks linting. Remove this once typescript-eslint supports the TS 7 compiler.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## Overview

Renovate models every package independently, so when two packages pin each other it raises a PR bumping one half of the pair — which can never go green. That's the whole story behind three of the stale PRs in the backlog: #206 (eslint 9.39.5), #324 (eslint-config 25) and #327 (eslint 10) are the same incompatibility seen from three angles, each crashing inside a lint rule because `eslint` and the plugins bundled in `@cloudfour/eslint-config` are version-locked. The oldest has been open since March. Grouping them means the next occurrence arrives as one PR that either works or doesn't.

The two version ceilings are a different kind of fix. Without them Renovate will immediately recreate PRs we're about to close as unmergeable — most obviously TypeScript 7, which `typescript-eslint` can't support yet (it declares `typescript: '>=4.8.4 <6.1.0'`). Both ceilings carry a `description` field stating the condition for lifting them, since JSON has nowhere else to put that note and a silent ceiling is worse than no ceiling.

`@types/node` is the one judgment call worth flagging: it's now held to 22.x so it tracks the `engines` floor rather than the newest Node. The reasoning is that a Node 24-only API should fail to type-check during development rather than reach a user running Node 22.

## Screenshots

## Testing

There's no CI check for Renovate config, so this is worth a quick manual pass.

- [ ] Run `npx --package renovate renovate-config-validator .renovaterc.json` — it should report `Config validated successfully`.
- [ ] After merging, open the [Renovate Dependency Dashboard issue](https://github.com/cloudfour/lighthouse-parade/issues) and confirm pending eslint updates are now listed under a single **eslint** group rather than as separate entries.
- [ ] Confirm no new PR appears proposing TypeScript 7 or `@types/node` 23 or higher. Existing ones aren't closed automatically, so ignore any already open.

## Notes for the reviewer

The `typescript` ceiling is explicitly temporary. When `typescript-eslint` ships TS 7 support, delete that rule and Renovate will raise the upgrade on its own. The `description` field is there so whoever hits it later doesn't have to reconstruct the reasoning.

---

Part of the Renovate backlog cleanup. Prevents the situation behind #206, #324, #327 and #355 from recurring.