### PR TITLE
Restore the shebang on the CLI entry point

### DIFF
--- a/.changeset/great-pugs-repeat.md
+++ b/.changeset/great-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-parade': patch
+---
+
+Restore the `#!/usr/bin/env node` shebang on the CLI entry point. Without it, npm symlinks `node_modules/.bin/lighthouse-parade` at a file the shell cannot execute, so `npx lighthouse-parade` and globally installed runs failed with `import: command not found`. Only `node path/to/cli.js` worked.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,17 @@ export default [
     ignores: ['dist/**/*'],
   },
   {
+    // `bin` points at the compiled dist/src/cli.js, so n/hashbang can't tell
+    // that src/cli.ts is the source of an executable. It reports the shebang as
+    // unnecessary and `--fix` deletes it, which silently breaks `npx
+    // lighthouse-parade` and global installs. That is how the shebang was lost
+    // in #184 and shipped broken until this was caught.
+    files: ['src/cli.ts'],
+    rules: {
+      'n/hashbang': 'off',
+    },
+  },
+  {
     rules: {
       // Your overrides here
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as os from 'node:os';

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -55,6 +55,17 @@ describe('lighthouse-parade CLI', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lighthouse-parade-test-'));
   }, 180_000);
 
+  // Npm symlinks node_modules/.bin straight at the built file, so without a
+  // shebang the shell tries to run it and every install method except
+  // `node path/to/cli.js` fails with `import: command not found`. The shebang
+  // was dropped once already, in an unrelated import reorder, and nothing
+  // noticed because no test ran the file as a binary.
+  it('starts with a shebang so it can run as a binary', () => {
+    const built = fs.readFileSync(cliPath, 'utf8');
+
+    expect(built.split('\n')[0]).toBe('#!/usr/bin/env node');
+  });
+
   it('prints usage when asked for help', async () => {
     const { stdout, exitCode } = await runCli(['--help'], tempDir);
 


### PR DESCRIPTION
## Overview

`npx lighthouse-parade` and globally installed runs are currently broken on `main`. npm symlinks `node_modules/.bin/lighthouse-parade` directly at the built file, and because that file has no shebang the shell tries to execute JavaScript as a shell script:

```
$ npx lighthouse-parade --version
line 1: import: command not found
line 2: import: command not found
```

Every install path fails except invoking node explicitly (`node ./node_modules/lighthouse-parade/dist/src/cli.js`), which is why local development never hit it. The published 2.1.0 predates the regression and still works — this has been sitting unreleased on `main` since February 2025, so **3.0.0 would have been the first broken release**.

The root cause is worth recording, because it will happen again otherwise. `bin` points at the compiled `dist/src/cli.js`, so the `n/hashbang` rule can't tell that `src/cli.ts` is the source of an executable. It reports the shebang as unnecessary, and `eslint --fix` deletes it — which is exactly what happened during the ESLint v9 upgrade in #184, buried in an import reorder. Turning the rule off for that one file is what makes the fix stick; without it the next `npm run lint` removes the line again. I verified that: with the rule active, `npx eslint src/cli.ts --fix` strips the shebang immediately.

Found by `package-json/require-bin-shebang`, a rule that arrives with `@cloudfour/eslint-config` 26 in the pending eslint upgrade. Pulling it out into its own PR so a release-blocking fix isn't queued behind a large lint refactor.

## Screenshots

## Testing

The regression test asserts the built file starts with the shebang, but the failure this prevents only appears through a real install, so that's worth doing by hand once.

- [ ] Run `npm run build`, then `head -1 dist/src/cli.js` — it should print `#!/usr/bin/env node`.
- [ ] Run `npm pack`, then in a scratch directory elsewhere run `npm init -y` and `npm install /path/to/lighthouse-parade-2.1.0.tgz`.
- [ ] From that scratch directory run `./node_modules/.bin/lighthouse-parade --version` — it should print the version. Before this change it printed a series of `import: command not found` errors.
- [ ] Run `npx lighthouse-parade --help` from the same directory — you should get the usage text.
- [ ] Back in the repo, run `npx eslint src/cli.ts --fix` and then `head -1 src/cli.ts` — the shebang should still be there. This confirms the rule override is doing its job.

## Notes for the reviewer

The changeset is a `patch`. It's arguably closer to a fix for something never released, but 3.0.0 is already going out as a major and this describes a real user-facing breakage, so it seemed worth an explicit changelog line rather than staying silent.

---

Part of the Renovate backlog cleanup. Related: #362 (the smoke test this extends), #377 (the eslint upgrade whose new rule surfaced this).