### PR TITLE
Use setup-node's built-in npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: 24.19.0
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -23,12 +26,7 @@ jobs:
         uses: actions/setup-node@v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache node modules
-        uses: actions/cache@v6.1.0
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci
       - name: Run tests
@@ -39,16 +37,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: 24.19.0
-      - name: Cache node modules
-        uses: actions/cache@v6.1.0
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci
       - name: Run Type Checker
@@ -59,16 +52,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: 24.19.0
-      - name: Cache node modules
-        uses: actions/cache@v6.1.0
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci
       - name: Run Linter


### PR DESCRIPTION
## Overview

Replaces the hand-rolled `actions/cache` blocks in all three CI jobs with `actions/setup-node`'s built-in `cache: 'npm'`. This repo was one of the last outliers — 27 of the 29 cache-using workflow files across the org already use the built-in, so the value here is removing drift rather than any performance gain.

**This deliberately does not fix the concurrent-save warning.** The built-in key is `node-cache-${platform}-${arch}-${packageManager}-${fileHash}`, which has no job scoping, so all four jobs still compute one key, one wins the save and three log `Unable to reserve cache`. That's worth being explicit about because it's the thing #352 asks about: the warning is benign, costs nothing in wall clock since the jobs run concurrently, and bills nothing at all here — the timing endpoint reports `0 ms` billable for every job, because public repos don't consume Actions minutes. The one-designated-saver workaround (`actions/cache` in one job, `actions/cache/restore` in the rest) was considered and rejected as too bespoke to copy across repos, on the grounds that copy-paste drift is the failure mode worth optimizing against, not eight seconds of discarded compression.

Also lifts the pinned Node version into a workflow-level `env`, so `type` and `lint` share one definition instead of repeating `24.19.0`. The version stays out of the cache key on purpose — cached npm tarballs are Node-agnostic, which is why the built-in key omits it too.

## Screenshots

## Testing

Caching only shows its behavior across consecutive runs, so this is easier to confirm on the Checks tab than locally.

- [ ] Open this PR's first CI run and confirm all four jobs pass — `test (22.x)`, `test (24.x)`, `type` and `lint`.
- [ ] In any job's log, expand the **Use Node.js** step. It should now include a "Cache saved" or "Cache restored" line; there should no longer be a separate "Cache node modules" step at all.
- [ ] Push any trivial commit to this branch to trigger a second run, then check a job's log for `Cache restored from key: node-cache-Linux-x64-npm-...`. The old key format began with `Linux-node-`.
- [ ] Expect to still see `Unable to reserve cache` in the post-job section of three of the four jobs. That is the known, accepted behavior described above, not a regression.

## Notes for the reviewer

**`release.yml` is untouched, deliberately.** It uses `actions/setup-node@master` rather than a pinned version, and attaching cache behavior to a floating ref seemed like a different decision from this one — especially on the workflow that publishes to npm. Both that and the `changesets/action@master` pin next to it are worth addressing, but as their own change.

**Cache storage is currently at 97% of the 10 GB limit** (85 entries, ~9,949 MB). That's an artifact of today's dependency work churning the lockfile on nearly every PR — 67 of those entries were created today. GitHub's 7-day expiry clears it without intervention, so it's worth re-checking in a week rather than adding cleanup tooling now.

---

Addresses #352.