### PR TITLE
Pin release actions and migrate to changesets/action v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,19 @@ on:
     branches:
       - main
 
+env:
+  NODE_VERSION: 24.19.0
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Required by changesets/action v2 to commit version changes and open the
+    # release PR. Declaring them explicitly also drops every other permission
+    # the default token would otherwise carry.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7.0.1
@@ -16,21 +25,28 @@ jobs:
           # Fetch all git history for correct changelog commits
           fetch-depth: 0
 
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v7.0.0
         with:
-          node-version: 24.19.0
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          # Writes an .npmrc that reads NODE_AUTH_TOKEN. changesets/action v2
+          # no longer writes one from NPM_TOKEN itself, so without this the
+          # publish step has no credentials.
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm ci
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v2.1.1
         with:
-          publish: npm run release
-          version: npm run version
-          title: 'Publish Next Version'
-          commit: 'Publish Next Version'
+          publish-script: npm run release
+          version-script: npm run version
+          pr-title: 'Publish Next Version'
+          commit-message: 'Publish Next Version'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # v2 removed support for passing a token via GITHUB_TOKEN. The
+          # `github-token` input defaults to the GitHub-provided token, which
+          # is what this workflow used before, so it is left unset.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

`release.yml` was the last place in this repo tracking action branches instead of versions. `actions/setup-node@master` is a straight pin to `v7.0.0`, matching `ci.yml`, and picks up the npm cache that `ci.yml` already uses — that was deliberately left out of #388 because attaching cache behavior to a floating ref was the risk being avoided.

`changesets/action@master` turned out to be a worse problem than "unpinned". That repository's default branch is `main`, and **`master` was last committed to in November 2021** — while the action has shipped v2.0.0, v2.1.0 and v2.1.1 in the past two weeks. So the ref wasn't drifting with upstream; it was frozen on a four-year-old build, with nothing to signal that development had moved. Renovate can see the entry on the Dependency Dashboard but can't propose an upgrade from a branch ref, which is why it never surfaced.

That means the pin can't be done on its own. v2 renames **every input this workflow used**, and changes how both tokens are supplied. Details below, since this is the workflow that publishes to npm and the failure modes are quiet ones.

## Screenshots

## Testing

There is no way to exercise this without an actual release, so the useful review here is reading rather than running. The steps below are what to check once it does run.

- [ ] Read the diff against [the v2 API table](https://github.com/changesets/action/tree/v2.1.1#api) and confirm all four renamed inputs match: `publish-script`, `version-script`, `pr-title`, `commit-message`.
- [ ] After merging, watch the first `Release` run on `main`. It should update the existing "Publish Next Version" PR (#161) rather than opening a second one — the `pr-title` value is unchanged, so it should match the existing PR.
- [ ] When 3.0.0 is actually published, confirm the npm publish step authenticates. This is the change most likely to fail: v2 stopped writing an `.npmrc` from `NPM_TOKEN`, so auth now comes from `setup-node`'s `registry-url` plus `NODE_AUTH_TOKEN`. A failure here looks like `ENEEDAUTH` or a 401 from the registry, not a workflow syntax error.
- [ ] Confirm the release commit and tag land on `main` as usual. v2 pushes them through the GitHub API by default rather than the Git CLI, so they will be signed by GitHub and attributed to the token owner — expect the commit author to look different from previous releases.

## Notes for the reviewer

**Three breaking changes needed handling beyond the renames:**

1. **`GITHUB_TOKEN` env var is ignored in v2.** The `github-token` input now has to be explicit — but it defaults to the GitHub-provided token, which is exactly what this workflow was passing. So it's dropped rather than converted.
2. **`NPM_TOKEN` env var no longer configures npm.** v2 removed its `.npmrc` handling entirely and directs you to `setup-node`'s `registry-url` with `NODE_AUTH_TOKEN`. The repository secret is unchanged; only the variable name it's bound to differs.
3. **`permissions` is now required.** v2's docs call for `contents: write` and `pull-requests: write`. Declaring them explicitly also drops every other permission the default token would carry, which is a small tightening.

**v2 requires Changesets v3.** This repo is on `@changesets/cli` 3.0.1, so that's satisfied. Worth knowing because the v1 line is what pairs with Changesets v2.

**Timing.** I'd flagged doing this after 3.0.0 ships rather than before, on the grounds that altering the publish path immediately before using it carries avoidable risk. Going ahead per your call — but that's the reason the testing notes above are more detailed than usual, and it's worth watching the first release run rather than assuming it worked.

The equivalent change for `cloudfour.com-patterns` is in cloudfour/cloudfour.com-patterns#2451.

---

Addresses the remaining floating refs noted in #352.
