### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,20 +1,7 @@
 {
-  "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>cloudfour/renovate-config:library"],
   "packageRules": [
-    {
-      "matchDepTypes": ["peerDependencies", "engines"],
-      "rangeStrategy": "replace"
-    },
-    {
-      "description": "ESLint and the shared config pin each other's plugins, so bumping either one alone produces a PR that crashes inside a lint rule. Keep them in a single PR.",
-      "groupName": "eslint",
-      "matchPackageNames": [
-        "eslint",
-        "@cloudfour/eslint-config",
-        "typescript-eslint"
-      ]
-    },
     {
       "description": "csv-parse and csv-stringify move their export paths together, and both are imported from the same modules here.",
       "groupName": "csv",


### PR DESCRIPTION
## Overview

[`cloudfour/renovate-config`](https://github.com/cloudfour/renovate-config) is now the shared Renovate preset source for Cloud Four repos, so a config change we want everywhere is a one-file edit instead of a hand-edit across two dozen repos. This replaces the shared portion of the local config with a one-line `extends` and keeps the three rules specific to this repo.

Two rules are absorbed by the shared preset and removed here: the `peerDependencies`/`engines` range rule (now in `library`) and the `eslint` group (now in `default`, with the same package list). The `csv` group and the two `allowedVersions` ceilings stay, since they're specific to this project's dependencies.

This repo's existing rules were already the model for how local overrides should be documented — issue #1 cites them as the pattern the other repos were brought up to. Their `description` fields are carried over unchanged.

The `library` preset matters concretely here rather than hypothetically: this package declares `"engines": { "node": "^22.19.0 || >=24.0.0" }`, and on the plain `default` preset the shared `:pinVersions` would collapse that range to a single exact version, breaking installs for anyone whose Node doesn't match.

## Screenshots

## Testing

- [ ] Open `.renovaterc.json` on this branch and confirm three rules remain: the `csv` group, the `@types/node` ceiling, and the `typescript` ceiling
- [ ] After merging, open the **Dependency Dashboard** issue and wait for Renovate to run (or tick the checkbox at the bottom of the dashboard to request an immediate run)
- [ ] The dashboard should render its usual list of pending updates with no error banner at the top. A red "Config Validation" or "Preset Not Found" warning would mean the preset failed to resolve
- [ ] Confirm the dashboard does **not** offer a `@types/node` 23-or-newer update, or a TypeScript 7 update — those ceilings should still hold
- [ ] Confirm `csv`, `csv-parse` and `csv-stringify` still appear grouped in a single PR rather than as three separate ones
- [ ] Confirm eslint and `@cloudfour/eslint-config` still arrive grouped in one PR — that grouping now comes from the shared preset instead of this file
- [ ] Check that `engines` in `package.json` keeps its range (`^22.19.0 || >=24.0.0`) and is not pinned to an exact version on the next Node-related update

---

Part of cloudfour/renovate-config#1
