### PR TITLE
Publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Lets the job mint the OIDC token npm exchanges for short-lived publish
+      # credentials. Without it, npm silently falls back to looking for a token.
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7.0.1
@@ -30,14 +33,23 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          # Writes an .npmrc that reads NODE_AUTH_TOKEN. changesets/action v2
-          # no longer writes one from NPM_TOKEN itself, so without this the
-          # publish step has no credentials.
+          # Required for trusted publishing, not just for tokens: npm only
+          # attempts the OIDC exchange when an .npmrc points at the registry.
+          # Omitting this makes publishes fail as though unauthenticated.
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm ci
 
+      # No npm credentials are passed here. `changeset publish` shells out to
+      # `npm publish`, which detects the OIDC environment and authenticates
+      # itself against the trusted publisher configured on npmjs.com. That
+      # config names this file, so renaming or splitting this workflow means
+      # updating the package settings on npm to match.
+      #
+      # v2 removed support for passing a token via GITHUB_TOKEN. The
+      # `github-token` input defaults to the GitHub-provided token, which is
+      # what this workflow used before, so it is left unset.
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v2.1.1
         with:
@@ -45,8 +57,3 @@ jobs:
           version-script: npm run version
           pr-title: 'Publish Next Version'
           commit-message: 'Publish Next Version'
-        env:
-          # v2 removed support for passing a token via GITHUB_TOKEN. The
-          # `github-token` input defaults to the GitHub-provided token, which
-          # is what this workflow used before, so it is left unset.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

Every `Release` run on `main` has been failing with `E404: Not Found - PUT https://registry.npmjs.org/lighthouse-parade`, leaving `3.0.0` staged but unpublished. The cause is not repo-specific: npm [permanently revoked all classic tokens on 2025-12-09](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/), and our `NPM_TOKEN` secret dates from 2020. (An earlier npm ownership problem, issue #390, was a separate blocker that has since been resolved — the `E404` persists after that fix, which is what points at the credential.)

Rather than mint a replacement, this switches to OIDC trusted publishing. npm now [caps granular write tokens at a 90-day lifetime](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/), and this package releases a few times a year — a token would be expired at nearly every release. Trusted publishing removes the stored credential entirely and adds provenance attestations. The change is small because `changeset publish` shells out to `npm publish`, which detects OIDC on its own: we add `id-token: write` and drop `NODE_AUTH_TOKEN`. Verified that CI's Node 24.19.0 ships npm 11.17.0 (OIDC needs >= 11.5.1), that `registry-url` was already set, and that `repository` case-matches the GitHub repo as provenance requires.

This depends on the trusted publisher being configured on npmjs.com first, pointing at `release.yml` in this repo. **Do not merge before that is in place** — the publish will keep failing, just with a different error.

## Screenshots

## Testing

This one can't be exercised before merge — the Release workflow only runs on `main`, and npm won't accept a publish from a branch.

- [ ] Confirm the trusted publisher is configured at npmjs.com → `lighthouse-parade` → Settings, listing repository `cloudfour/lighthouse-parade` and workflow `release.yml`
- [ ] After merging, open the Actions tab and watch the **Release** run. It should finish green, where every run for the past several weeks has failed
- [ ] In its log, the publish step should report `lighthouse-parade@3.0.0` published, with no `E404`
- [ ] Run `npm view lighthouse-parade version` — it should report `3.0.0`, up from `2.1.0`
- [ ] On the [npm package page](https://www.npmjs.com/package/lighthouse-parade), the 3.0.0 version should carry a green **Provenance** badge linking back to the Actions run
- [ ] Confirm a `v3.0.0` tag and a matching GitHub release now exist — neither did before, because changesets publishes before tagging

Once the release succeeds, the now-unused `NPM_TOKEN` repo secret can be deleted.